### PR TITLE
Add support for C++17

### DIFF
--- a/wykobi_minimum_bounding_ball.inl
+++ b/wykobi_minimum_bounding_ball.inl
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <vector>
 #include <iterator>
+#include <random>
 
 
 namespace wykobi
@@ -62,7 +63,9 @@ namespace wykobi
 
             std::copy(begin,end,std::back_inserter(point_list));
 
-            std::random_shuffle(point_list.begin(),point_list.end());
+            std::random_device random_device;
+            std::mt19937 random_engine(random_device());
+            std::shuffle(point_list.begin(),point_list.end(),random_engine);
 
             circle = make_circle(*point_list.begin(),*(point_list.begin() + 1));
 
@@ -81,7 +84,9 @@ namespace wykobi
                                              InputIterator end,
                                              const point2d<T>& q)
          {
-            std::random_shuffle(begin,end);
+            std::random_device random_device;
+            std::mt19937 random_engine(random_device());
+            std::shuffle(begin,end,random_engine);
 
             circle<T> circle = make_circle(q,*begin);
 
@@ -102,7 +107,9 @@ namespace wykobi
                                               const point2d<T>& q1,
                                               const point2d<T>& q2)
          {
-            std::random_shuffle(begin,end);
+            std::random_device random_device;
+            std::mt19937 random_engine(random_device());
+            std::shuffle(begin,end,random_engine);
 
             circle<T> circle = make_circle(q1,q2);
 


### PR DESCRIPTION
Replace `random_shuffle` with `shuffle`, as `random_shuffle` was removed from C++17
https://en.cppreference.com/w/cpp/algorithm/random_shuffle