### PR TITLE
Fix out-of-bound accesses to unallocated LUT memory

### DIFF
--- a/wykobi.hpp
+++ b/wykobi.hpp
@@ -785,6 +785,9 @@ namespace wykobi
       const static unsigned int TableSize = 360;
 
       trig_luts()
+      : sin_(TableSize),
+        cos_(TableSize),
+        tan_(TableSize)
       {
          for (std::size_t i = 0; i < 360; ++i)
          {


### PR DESCRIPTION
Make sure that the LUTs are allocated with the proper size before writing to them.

This fixes a bug that inevitably triggers a segmentation fault within the constructor of `trig_luts`. It was introduced by commit d938c78b353d248146469b3e314a0dd4a16e3cd6.